### PR TITLE
fix update progress (fixes #78)

### DIFF
--- a/android/src/main/kotlin/com/example/flutter_video_compress/FFmpegCommander.kt
+++ b/android/src/main/kotlin/com/example/flutter_video_compress/FFmpegCommander.kt
@@ -150,7 +150,7 @@ class FFmpegCommander(private val context: Context, private val channelName: Str
                 val totalTimeStr = message.replace(reg, "$1")
                 val time = utility.timeStrToTimestamp(totalTimeStr.trim())
                 MethodChannel(messenger, channelName)
-                        .invokeMethod("updateProgress", ((time / totalTime) * 100).toString())
+                        .invokeMethod("updateProgress", ((time.toDouble() / totalTime.toDouble()) * 100).toString())
             } catch (e: Exception) {
                 print(e.stackTrace)
             }


### PR DESCRIPTION
The division between integers was causing the progress to be 0 at the beginning and 100 in the end, without any progress in between.